### PR TITLE
Standardized README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ clj-multihash
 [![API codox](https://img.shields.io/badge/doc-API-blue.svg)](https://greglook.github.io/clj-multihash/api/multihash.core.html)
 [![marginalia docs](https://img.shields.io/badge/doc-marginalia-blue.png)](https://greglook.github.io/clj-multihash/marginalia/uberdoc.html)
 [![Join the chat at https://gitter.im/greglook/clj-multihash](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/greglook/clj-multihash)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+
+> Clojure implementation of the Multihash spec
 
 A Clojure library implementing the
-[multihash](https://github.com/jbenet/multihash) standard. This provides an
+[multihash](https://github.com/multiformats/multihash) standard. This provides an
 extensible, efficient binary representation for cryptographic hashes.
 
-## Installation
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+  - [Serialization](#serialization)
+- [Maintainers](#maintainers)
+- [Contribute](#contribute)
+- [License](#license)
+
+## Install
 
 Library releases are published on Clojars. To use the latest version with
 Leiningen, add the following dependency to your project definition:
@@ -93,7 +105,19 @@ true
 Decoding is implemented as a protocol, so it can be extended to other data
 source types as needed.
 
+## Maintainers
+
+Captain: [@greglook](https://github.com/greglook).
+
+## Contribute
+
+Contributions welcome. Please check out [the issues](https://github.com/multiformats/clj-multihash/issues).
+
+Check out our [contributing document](https://github.com/multiformats/multiformats/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to multiformats are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
 ## License
 
 This is free and unencumbered software released into the public domain.
-See the UNLICENSE file for more information.
+See the [UNLICENSE](UNLICENSE) file for more information.


### PR DESCRIPTION
Made this README compatible with github.com/RichardLitt/standard-readme. Added a contribute section, maintainers, a badge to the IPFS chatroom, and the github description

See https://github.com/multiformats/multiformats/issues/13
