### PR TITLE
[cljs] Use type symbol when extending base type

### DIFF
--- a/src/multihash/core.cljc
+++ b/src/multihash/core.cljc
@@ -254,7 +254,7 @@
 
 
   #?(:clj java.lang.String
-     :cljs js/String)
+     :cljs string)
 
   (decode
     [source]


### PR DESCRIPTION
As per https://cljs.github.io/api/cljs.core/extend-type when extending js/String
the special symbol 'string should be used. This still makes the protocol work
with strings but without changing the js/String prototype.

This removes a compile-time warning.