### PR TITLE
Varint support for code and length

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,8 @@
    [lein-doo "0.1.8" :exclusions [org.clojure/clojurescript]]]
 
   :dependencies
-  [[mvxcvi/alphabase "1.0.0"]]
+  [[mvxcvi/alphabase "1.0.0"]
+   [multiformats/clj-varint "0.1.1"]]
 
   :cljsbuild
   {:builds {:test {:source-paths ["src" "test"]


### PR DESCRIPTION
Fixes #12

This PR requires `multiformats/clj-varint` `0.1.1` to be released. Current release (`0.1.0`) does not include the VarInt class.