### PR TITLE
Bump alphabase dependency version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
    [lein-doo "0.1.8" :exclusions [org.clojure/clojurescript]]]
 
   :dependencies
-  [[mvxcvi/alphabase "1.0.0"]]
+  [[mvxcvi/alphabase "2.1.0"]]
 
   :cljsbuild
   {:builds {:test {:source-paths ["src" "test"]


### PR DESCRIPTION
Per slack conversation, we need this for Java 11 support.